### PR TITLE
fix utf16 to unicode transformation for high range surrogates

### DIFF
--- a/libuna/libuna_unicode_character.c
+++ b/libuna/libuna_unicode_character.c
@@ -4629,7 +4629,7 @@ int libuna_unicode_character_copy_from_utf16(
 		{
 			*unicode_character  -= LIBUNA_UNICODE_SURROGATE_HIGH_RANGE_START;
 			*unicode_character <<= 10;
-			*unicode_character  += utf16_surrogate - LIBUNA_UNICODE_SURROGATE_LOW_RANGE_END;
+			*unicode_character  += utf16_surrogate - LIBUNA_UNICODE_SURROGATE_LOW_RANGE_START;
 			*unicode_character  += 0x010000;
 		}
 		else
@@ -4899,7 +4899,7 @@ int libuna_unicode_character_copy_from_utf16_stream(
 		}
 		safe_unicode_character  -= LIBUNA_UNICODE_SURROGATE_HIGH_RANGE_START;
 		safe_unicode_character <<= 10;
-		safe_unicode_character  += utf16_surrogate - LIBUNA_UNICODE_SURROGATE_LOW_RANGE_END;
+		safe_unicode_character  += utf16_surrogate - LIBUNA_UNICODE_SURROGATE_LOW_RANGE_START;
 		safe_unicode_character  += 0x010000;
 	}
 	*unicode_character  = safe_unicode_character;

--- a/tests/una_test_unicode_character.c
+++ b/tests/una_test_unicode_character.c
@@ -1962,6 +1962,7 @@ int una_test_unicode_character_copy_from_utf16(
      void )
 {
 	uint16_t utf16_stream[ 2 ] = { 'A', 0 };
+	uint16_t emoji_stream[ 2 ] = { 55357, 56840 };
 
 	libuna_error_t *error                        = NULL;
 	libuna_unicode_character_t unicode_character = 0;
@@ -1993,6 +1994,36 @@ int una_test_unicode_character_copy_from_utf16(
 	 "utf16_stream_index",
 	 utf16_stream_index,
 	 (size_t) 1 );
+
+	UNA_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	/* Test emoji case
+	 */
+	utf16_stream_index = 0;
+
+	result = libuna_unicode_character_copy_from_utf16(
+	          &unicode_character,
+	          emoji_stream,
+	          2,
+	          &utf16_stream_index,
+	          &error );
+
+	UNA_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 1 );
+
+	UNA_TEST_ASSERT_EQUAL_UINT32(
+	 "unicode_character",
+	 unicode_character,
+	 (uint32_t) 0x0001F608UL );
+
+	UNA_TEST_ASSERT_EQUAL_SIZE(
+	 "utf16_stream_index",
+	 utf16_stream_index,
+	 (size_t) 2 );
 
 	UNA_TEST_ASSERT_IS_NULL(
 	 "error",
@@ -2239,6 +2270,7 @@ int una_test_unicode_character_copy_from_utf16_stream(
 {
 	uint8_t utf16_stream1[ 4 ]                   = { 0, 'A', 0, 0 };
 	uint8_t utf16_stream2[ 4 ]                   = { 'A', 0, 0, 0 };
+	uint8_t emoji_stream[ 6 ]                    = { 61, 216, 8, 222, 0, 0 };
 
 	libuna_error_t *error                        = NULL;
 	libuna_unicode_character_t unicode_character = 0;
@@ -2304,6 +2336,38 @@ int una_test_unicode_character_copy_from_utf16_stream(
 	UNA_TEST_ASSERT_IS_NULL(
 	 "error",
 	 error );
+
+	/* Test emoji case
+	*/
+	utf16_stream_index = 0;
+
+	result = libuna_unicode_character_copy_from_utf16_stream(
+	          &unicode_character,
+	          emoji_stream,
+	          4,
+	          &utf16_stream_index,
+              LIBUNA_ENDIAN_LITTLE,
+	          &error );
+
+	UNA_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 1 );
+
+	UNA_TEST_ASSERT_EQUAL_UINT32(
+	 "unicode_character",
+	 unicode_character,
+	 (uint32_t) 0x0001F608UL );
+
+	UNA_TEST_ASSERT_EQUAL_SIZE(
+	 "utf16_stream_index",
+	 utf16_stream_index,
+	 (size_t) 4 );
+
+	UNA_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
 
 	/* Test error cases
 	 */


### PR DESCRIPTION
I ran into an issue in libewf when reading an L01 that contained an entry with a name that included an emoji. I traced the issue to the the `libuna_unicode_character_copy_from_utf16_stream` function. The `LIBUNA_UNICODE_SURROGATE_LOW_RANGE_END` value was being used when the character was in the high range, when it should be using `LIBUNA_UNICODE_SURROGATE_LOW_RANGE_START`.

I also added some test cases, for the emoji case.