### PR TITLE
libuna_extern.h: fix incorrect macro usage

### DIFF
--- a/libuna/libuna_extern.h
+++ b/libuna/libuna_extern.h
@@ -24,8 +24,12 @@
 
 #include <common.h>
 
-#if defined( __has_attribute ) && __has_attribute( visibility ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if defined( __has_attribute ) && !defined( __CYGWIN__ ) && !defined( _WIN32 )
+#if __has_attribute( visibility )
 #define LIBUNA_INTERNAL	__attribute__((visibility("hidden"))) extern
+#else
+#define LIBUNA_INTERNAL	extern
+#endif
 #else
 #define LIBUNA_INTERNAL	extern
 #endif


### PR DESCRIPTION
Current code is wrong: if `__has_attribute` is _not_ defined, it breaks down.